### PR TITLE
Skybox reworked (a bit)

### DIFF
--- a/graphics/graphics.h
+++ b/graphics/graphics.h
@@ -395,7 +395,8 @@ bool Graphics_LoadSkyboxFS(Skybox *skybox, const char *path_up,
 							const char *path_back);
 
 void Graphics_UploadSkybox(Skybox *skybox);
-//TODO FIXME create unload/destroy skybox
+
+void Graphics_ReleaseSkybox(Skybox *skybox);
 
 /* MATERIALS */
 

--- a/graphics/graphics.h
+++ b/graphics/graphics.h
@@ -48,8 +48,6 @@ typedef struct GraphicsContext
 
 typedef struct GeneralPipelines
 {
-	SDL_GPUGraphicsPipeline *skybox;
-
 	//SIMPLE RENDERING (no post processing)
 	SDL_GPUGraphicsPipeline *simple;
 
@@ -166,6 +164,7 @@ typedef struct Skybox
 	Sampler *sampler;
 	SDL_GPUBuffer* vertex_buffer;
 	SDL_GPUBuffer* index_buffer;
+	SDL_GPUGraphicsPipeline *pipeline;
 } Skybox;
 
 /* MATERIAL */
@@ -339,8 +338,12 @@ void Graphics_DestroySpotlight(Spotlight *l);
 
 /* SHADERS AND PIPELINES */
 
-bool Graphics_CreatePipelineSkybox(const char *path_vs,
-										const char *path_fs);
+SDL_GPUShader* Graphics_LoadShader(const char *path,
+									SDL_GPUShaderStage stage,
+									Uint32 samplerCount,
+									Uint32 uniformBufferCount,
+									Uint32 storageBufferCount,
+									Uint32 storageTextureCount);
 
 bool Graphics_CreatePipelineSimple(const char *path_vs,
 									const char *path_fs);
@@ -379,6 +382,10 @@ bool Graphics_SetupDefaultTextures(const char *path_d,
 void Graphics_ReleaseDefaultTextures();
 
 /* SKYBOXES */
+
+bool Graphics_CreatePipelineSkybox(Skybox *skybox,
+									const char *path_vs,
+									const char *path_fs);
 
 bool Graphics_LoadSkyboxFS(Skybox *skybox, const char *path_up,
 							const char *path_down,

--- a/graphics/renderer.c
+++ b/graphics/renderer.c
@@ -102,7 +102,7 @@ static void drawskybox(Skybox *skybox, Camera *camera, SDL_GPURenderPass *render
 	Matrix4x4 skyboxviewproj;
 	skyboxviewproj = Matrix4x4_Mul(cam_view, camera->projection);
 
-	SDL_BindGPUGraphicsPipeline(render_pass, pipelines.skybox);
+	SDL_BindGPUGraphicsPipeline(render_pass, skybox->pipeline);
 	SDL_BindGPUVertexBuffers(render_pass, 0, &(SDL_GPUBufferBinding){ skybox->vertex_buffer, 0 }, 1);
 	SDL_BindGPUIndexBuffer(render_pass, &(SDL_GPUBufferBinding){ skybox->index_buffer, 0 }, SDL_GPU_INDEXELEMENTSIZE_32BIT);
 	SDL_BindGPUFragmentSamplers(render_pass, 0, &(SDL_GPUTextureSamplerBinding){ skybox->gputexture, skybox->sampler }, 1);

--- a/graphics/shaders.c
+++ b/graphics/shaders.c
@@ -25,7 +25,7 @@
 #include <fileio.h>
 #include <graphics.h>
 
-static SDL_GPUShader* loadshader(const char *path,
+SDL_GPUShader* Graphics_LoadShader(const char *path,
 									SDL_GPUShaderStage stage,
 									Uint32 samplerCount,
 									Uint32 uniformBufferCount,
@@ -59,77 +59,16 @@ static SDL_GPUShader* loadshader(const char *path,
 	return SDL_CreateGPUShader(context.device, &shader_info);
 }
 
-bool Graphics_CreatePipelineSkybox(const char *path_vs,
-										const char *path_fs)
-{
-	SDL_GPUShader *vsshader = loadshader(path_vs, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
-	if(vsshader == NULL)
-	{
-		SDL_Log("Failed to load skybox vertex shader.");
-		return false;
-	}
-	SDL_GPUShader *fsshader = loadshader(path_fs, SDL_GPU_SHADERSTAGE_FRAGMENT, 1, 0, 0, 0);
-	if(fsshader == NULL)
-	{
-		SDL_Log("Failed to load skybox fragment shader.");
-		return false;
-	}
-
-	SDL_GPUGraphicsPipelineCreateInfo pipeline_createinfo = { 0 };
-	pipeline_createinfo = (SDL_GPUGraphicsPipelineCreateInfo)
-	{
-		.target_info =
-		{
-			.num_color_targets = 1,
-			.color_target_descriptions = (SDL_GPUColorTargetDescription[]){{
-				.format = SDL_GetGPUSwapchainTextureFormat(context.device, context.window)
-			}}
-		},
-		.depth_stencil_state = (SDL_GPUDepthStencilState) {
-			.enable_depth_test = true,
-			.enable_depth_write = true,
-			.enable_stencil_test = false,
-			.compare_op = SDL_GPU_COMPAREOP_NEVER,
-			.write_mask = 0xFF
-		},
-		.vertex_input_state = (SDL_GPUVertexInputState){
-			.num_vertex_buffers = 1,
-			.vertex_buffer_descriptions = (SDL_GPUVertexBufferDescription[]){{
-				.slot = 0,
-				.input_rate = SDL_GPU_VERTEXINPUTRATE_VERTEX,
-				.instance_step_rate = 0,
-				.pitch = sizeof(Vector3)
-			}},
-			.num_vertex_attributes = 1,
-			.vertex_attributes = (SDL_GPUVertexAttribute[]){{
-				//position
-				.buffer_slot = 0,
-				.format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3,
-				.location = 0,
-				.offset = 0
-			}}
-		},
-		.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
-		.vertex_shader = vsshader,
-		.fragment_shader = fsshader
-	};
-	pipelines.skybox = SDL_CreateGPUGraphicsPipeline(context.device, &pipeline_createinfo);
-	SDL_ReleaseGPUShader(context.device, vsshader);
-	SDL_ReleaseGPUShader(context.device, fsshader);
-
-	return true;
-}
-
 bool Graphics_CreatePipelineSimple(const char *path_vs,
 									const char *path_fs)
 {
-	SDL_GPUShader *vsshader = loadshader(path_vs, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
+	SDL_GPUShader *vsshader = Graphics_LoadShader(path_vs, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
 	if(vsshader == NULL)
 	{
 		SDL_Log("Failed to load skybox vertex shader.");
 		return false;
 	}
-	SDL_GPUShader *fsshader = loadshader(path_fs, SDL_GPU_SHADERSTAGE_FRAGMENT, 1, 0, 0, 0);
+	SDL_GPUShader *fsshader = Graphics_LoadShader(path_fs, SDL_GPU_SHADERSTAGE_FRAGMENT, 1, 0, 0, 0);
 	if(fsshader == NULL)
 	{
 		SDL_Log("Failed to load skybox fragment shader.");
@@ -201,38 +140,38 @@ bool Graphics_CreatePipelineToon(const char *path_norm_vs,
 									const char *path_toon_vs,
 									const char *path_toon_fs)
 {
-	SDL_GPUShader *norm_vsshader = loadshader(path_norm_vs, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
+	SDL_GPUShader *norm_vsshader = Graphics_LoadShader(path_norm_vs, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
 	if(norm_vsshader == NULL)
 	{
 		SDL_Log("Failed to load skybox vertex shader.");
 		return false;
 	}
-	SDL_GPUShader *norm_fsshader = loadshader(path_norm_fs, SDL_GPU_SHADERSTAGE_FRAGMENT, 1, 0, 0, 0);
+	SDL_GPUShader *norm_fsshader = Graphics_LoadShader(path_norm_fs, SDL_GPU_SHADERSTAGE_FRAGMENT, 1, 0, 0, 0);
 	if(norm_fsshader == NULL)
 	{
 		SDL_Log("Failed to load skybox fragment shader.");
 		return false;
 	}
-	SDL_GPUShader *outl_vsshader = loadshader(path_outl_vs, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
+	SDL_GPUShader *outl_vsshader = Graphics_LoadShader(path_outl_vs, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
 	if(norm_vsshader == NULL)
 	{
 		SDL_Log("Failed to load skybox vertex shader.");
 		return false;
 	}
-	SDL_GPUShader *outl_fsshader = loadshader(path_outl_fs, SDL_GPU_SHADERSTAGE_FRAGMENT, 1, 0, 0, 0);
+	SDL_GPUShader *outl_fsshader = Graphics_LoadShader(path_outl_fs, SDL_GPU_SHADERSTAGE_FRAGMENT, 1, 0, 0, 0);
 	if(norm_fsshader == NULL)
 	{
 		SDL_Log("Failed to load skybox fragment shader.");
 		return false;
 	}
 	//didn't complete the shaders for this one, need to complete it
-	SDL_GPUShader *toon_vsshader = loadshader(path_toon_vs, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
+	SDL_GPUShader *toon_vsshader = Graphics_LoadShader(path_toon_vs, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
 	if(toon_vsshader == NULL)
 	{
 		SDL_Log("Failed to load skybox vertex shader.");
 		return false;
 	}
-	SDL_GPUShader *toon_fsshader = loadshader(path_toon_fs, SDL_GPU_SHADERSTAGE_FRAGMENT, 4, 1, 1, 0);
+	SDL_GPUShader *toon_fsshader = Graphics_LoadShader(path_toon_fs, SDL_GPU_SHADERSTAGE_FRAGMENT, 4, 1, 1, 0);
 	if(toon_fsshader == NULL)
 	{
 		SDL_Log("Failed to load skybox fragment shader.");

--- a/graphics/skybox.c
+++ b/graphics/skybox.c
@@ -68,6 +68,68 @@ static bool _loadtextureskybox_mem(Texture2D *texture,
 	return true;
 }
 
+bool Graphics_CreatePipelineSkybox(Skybox *skybox,
+									const char *path_vs,
+									const char *path_fs)
+{
+	SDL_GPUShader *vsshader = Graphics_LoadShader(path_vs, SDL_GPU_SHADERSTAGE_VERTEX, 0, 1, 0, 0);
+	if(vsshader == NULL)
+	{
+		SDL_Log("Failed to load skybox vertex shader.");
+		return false;
+	}
+	SDL_GPUShader *fsshader = Graphics_LoadShader(path_fs, SDL_GPU_SHADERSTAGE_FRAGMENT, 1, 0, 0, 0);
+	if(fsshader == NULL)
+	{
+		SDL_Log("Failed to load skybox fragment shader.");
+		return false;
+	}
+
+	SDL_GPUGraphicsPipelineCreateInfo pipeline_createinfo = { 0 };
+	pipeline_createinfo = (SDL_GPUGraphicsPipelineCreateInfo)
+	{
+		.target_info =
+		{
+			.num_color_targets = 1,
+			.color_target_descriptions = (SDL_GPUColorTargetDescription[]){{
+				.format = SDL_GetGPUSwapchainTextureFormat(context.device, context.window)
+			}}
+		},
+		.depth_stencil_state = (SDL_GPUDepthStencilState) {
+			.enable_depth_test = true,
+			.enable_depth_write = true,
+			.enable_stencil_test = false,
+			.compare_op = SDL_GPU_COMPAREOP_NEVER,
+			.write_mask = 0xFF
+		},
+		.vertex_input_state = (SDL_GPUVertexInputState){
+			.num_vertex_buffers = 1,
+			.vertex_buffer_descriptions = (SDL_GPUVertexBufferDescription[]){{
+				.slot = 0,
+				.input_rate = SDL_GPU_VERTEXINPUTRATE_VERTEX,
+				.instance_step_rate = 0,
+				.pitch = sizeof(Vector3)
+			}},
+			.num_vertex_attributes = 1,
+			.vertex_attributes = (SDL_GPUVertexAttribute[]){{
+				//position
+				.buffer_slot = 0,
+				.format = SDL_GPU_VERTEXELEMENTFORMAT_FLOAT3,
+				.location = 0,
+				.offset = 0
+			}}
+		},
+		.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
+		.vertex_shader = vsshader,
+		.fragment_shader = fsshader
+	};
+	skybox->pipeline = SDL_CreateGPUGraphicsPipeline(context.device, &pipeline_createinfo);
+	SDL_ReleaseGPUShader(context.device, vsshader);
+	SDL_ReleaseGPUShader(context.device, fsshader);
+
+	return true;
+}
+
 bool Graphics_LoadSkyboxFS(Skybox *skybox, const char *path_up,
 							const char *path_down,
 							const char *path_left,

--- a/graphics/skybox.c
+++ b/graphics/skybox.c
@@ -219,6 +219,11 @@ bool Graphics_LoadSkyboxFS(Skybox *skybox, const char *path_up,
 
 void Graphics_UploadSkybox(Skybox *skybox)
 {
+	if(skybox == NULL)
+	{
+		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Graphics: Error: failed to upload skybox, invalid structure.");
+		return;
+	}
 	//shape of skybox
 	SDL_GPUTransferBuffer* buffer_transferbuffer = SDL_CreateGPUTransferBuffer(
 		context.device,
@@ -355,4 +360,18 @@ void Graphics_UploadSkybox(Skybox *skybox)
 	SDL_ReleaseGPUTransferBuffer(context.device, texture_transferbuffer);
 
 	SDL_SubmitGPUCommandBuffer(cmdbuf);
+}
+
+void Graphics_ReleaseSkybox(Skybox *skybox)
+{
+	if(skybox == NULL)
+	{
+		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Graphics: Error: failed to release skybox, invalid structure.");
+		return;
+	}
+	SDL_ReleaseGPUGraphicsPipeline(context.device, skybox->pipeline);
+	SDL_ReleaseGPUTexture(context.device, skybox->gputexture);
+	SDL_ReleaseGPUSampler(context.device, skybox->sampler);
+	SDL_ReleaseGPUBuffer(context.device, skybox->vertex_buffer);
+	SDL_ReleaseGPUBuffer(context.device, skybox->index_buffer);
 }

--- a/leiden/leiden.c
+++ b/leiden/leiden.c
@@ -95,16 +95,6 @@ bool Leiden_Init(LeidenInitDesc *initdesc)
 		return 0;
 	}
 
-	//Start creating all the required pipelines
-	if(!Graphics_CreatePipelineSkybox(INIGetString(ini, "shaders", "skybox_vert"), INIGetString(ini, "shaders", "skybox_frag")))
-	{
-		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Failed to generate skybox pipeline...");
-		SDL_DestroyWindow(window);
-		FileIODeinit();
-		SDL_Quit();
-		return 0;
-	}
-
 	if(!Graphics_CreatePipelineSimple(INIGetString(ini, "shaders", "simple_vert"), INIGetString(ini, "shaders", "simple_frag")))
 	{
 		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Failed to generate simple pipeline...");
@@ -113,8 +103,6 @@ bool Leiden_Init(LeidenInitDesc *initdesc)
 		SDL_Quit();
 		return 0;
 	}
-
-	//TODO load toon pipelines
 
 	//create default textures
 	if(!Graphics_SetupDefaultTextures(INIGetString(ini, "default_textures", "default_diffuse"),

--- a/main.c
+++ b/main.c
@@ -103,6 +103,11 @@ int main(int argc, char *argv[])
 		//todo cleanup this
 		return -1;
 	}
+	if(!Graphics_CreatePipelineSkybox(&skybox, "shaders/skybox/skybox.vert.spv", "shaders/skybox/skybox.frag.spv"))
+	{
+		SDL_LogError(SDL_LOG_CATEGORY_ERROR, "Failed to generate skybox pipeline...");
+		return -1;
+	}
 	Graphics_UploadSkybox(&skybox);
 
 	Model *house = (Model*)SDL_malloc(sizeof(Model));

--- a/main.c
+++ b/main.c
@@ -228,6 +228,7 @@ int main(int argc, char *argv[])
 	Graphics_ReleaseSampler(sampler);
 	Graphics_FinishSimpleRendering();
 	Graphics_FinishToonRendering();
+	Graphics_ReleaseSkybox(&skybox);
 	Leiden_Deinit();
 
 	return 0;

--- a/screens/simple.c
+++ b/screens/simple.c
@@ -43,14 +43,18 @@ bool Simple_Setup()
 	//need to bring lookat, or a camera update thing
 	Graphics_InitCameraBasic(&cam_1, (Vector3){0.0f, 0.5f, 0.0f});
 
-	if(!Graphics_LoadSkyboxFS(skybox, "skybox/exosystem/top.jpg", "skybox/exosystem/bottom.jpg",
-								"skybox/exosystem/left.jpg", "skybox/exosystem/right.jpg",
-								"skybox/exosystem/front.jpg", "skybox/exosystem/back.jpg"))
+	skybox = (Skybox*)SDL_malloc(sizeof(Skybox));
+	if(skybox != NULL)
 	{
-		//todo cleanup this
-		return false;
+		if(!Graphics_LoadSkyboxFS(skybox, "skybox/exosystem/top.jpg", "skybox/exosystem/bottom.jpg",
+									"skybox/exosystem/left.jpg", "skybox/exosystem/right.jpg",
+									"skybox/exosystem/front.jpg", "skybox/exosystem/back.jpg"))
+		{
+			//todo cleanup this
+			return false;
+		}
+		Graphics_UploadSkybox(skybox);
 	}
-	Graphics_UploadSkybox(skybox);
 
 	house = (Model*)SDL_malloc(sizeof(Model));
 	if(house != NULL)
@@ -280,5 +284,6 @@ void Simple_Destroy()
 	SDL_free(house);
 	SDL_free(vroid_test);
 	Graphics_ReleaseSampler(sampler);
+	Graphics_ReleaseSkybox(skybox);
 	return;
 }

--- a/screens/simple.c
+++ b/screens/simple.c
@@ -153,7 +153,7 @@ static void drawskybox(Skybox *skybox, Camera *camera, SDL_GPURenderPass *render
 	Matrix4x4 skyboxviewproj;
 	skyboxviewproj = Matrix4x4_Mul(cam_view, camera->projection);
 
-	SDL_BindGPUGraphicsPipeline(render_pass, pipelines.skybox);
+	SDL_BindGPUGraphicsPipeline(render_pass, skybox->pipeline);
 	SDL_BindGPUVertexBuffers(render_pass, 0, &(SDL_GPUBufferBinding){ skybox->vertex_buffer, 0 }, 1);
 	SDL_BindGPUIndexBuffer(render_pass, &(SDL_GPUBufferBinding){ skybox->index_buffer, 0 }, SDL_GPU_INDEXELEMENTSIZE_32BIT);
 	SDL_BindGPUFragmentSamplers(render_pass, 0, &(SDL_GPUTextureSamplerBinding){ skybox->gputexture, skybox->sampler }, 1);


### PR DESCRIPTION
Small skybox refactor.

Removed global pipeline for skybox - users need to provide shaders before using instead of startup. Allows for customized shaders later. This reflects a move away from the graphics library idea I had before.

Also made a way to kill the skybox.