### PR TITLE
Fixed double key capturing issue

### DIFF
--- a/src/screens/splash.c
+++ b/src/screens/splash.c
@@ -199,22 +199,24 @@ void SplashScreen_Logic(SDL_Event event)
 		}
 		if(event.type == SDL_EVENT_KEY_DOWN)
 		{
-			if(event.key.key != SDLK_Q)
-			{
-				SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "going to cel shading test");
-				if(TestScreen1_Setup())
-				{
-					SplashScreen_Destroy();
-					current_screen = SCREEN_TEST;
-				}
-			}
-			else
+			if(event.key.key == SDLK_Q)
 			{
 				SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "going to physics test");
 				if(TestScreen2_Setup())
 				{
 					SplashScreen_Destroy();
 					current_screen = SCREEN_TEST2;
+					break;
+				}
+			}
+			else
+			{
+				SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, "going to cel shading test");
+				if(TestScreen1_Setup())
+				{
+					SplashScreen_Destroy();
+					current_screen = SCREEN_TEST;
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
Before, while in splash screen, if you hit two keys at the same time it was causing a segmentation fault.

How? Splash screen is set to get any key to move to the test scene 1 (cel shading scene) except when pressing Q that would move to physics test screen. So, if you, by accident, pressed two keys at the same time, it get the first key (one of them would be the first), clean up splash and then, instead of moving to another screen, it would proceed to process the second key, cleaning up stuff that was already cleaned before. Boom, segfault.

Fixed it by placing a break on the event loop, getting out of it after cleaning splash screen data.